### PR TITLE
Re-enable cucumber concurrency

### DIFF
--- a/tests/cucumber/main.rs
+++ b/tests/cucumber/main.rs
@@ -70,10 +70,5 @@ async fn contest_is_running(world: &mut ContestWorld) {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-  ContestWorld::cucumber()
-    .fail_fast()
-    .fail_on_skipped()
-    .max_concurrent_scenarios(Some(1))
-    .run_and_exit("features/")
-    .await;
+  ContestWorld::cucumber().fail_fast().fail_on_skipped().run_and_exit("features/").await;
 }


### PR DESCRIPTION
Now that the test flakiness is fixed, we can run the end-to-end tests concurrently again.